### PR TITLE
Load database path from config and document check_for

### DIFF
--- a/monopolpy_companion/lib/common/utilities/db_man.py
+++ b/monopolpy_companion/lib/common/utilities/db_man.py
@@ -1,12 +1,36 @@
-from lib.common.setup_env import db_path, os
+"""Utility helpers for working with the player database path.
 
-def check_for(path=None):
-    if path:
-        path = path
-    else:
-        path = db_path
+This module previously relied on ``lib.common.setup_env`` which no longer
+exists. The database path is now loaded from the project's YAML
+configuration file.
+"""
 
-    if os.path.exists(os.path.abspath(path)):
-        return True
-    else:
-        return False
+import os
+from pathlib import Path
+
+import yaml
+
+
+_CONFIG_PATH = Path(__file__).resolve().parents[3] / "conf" / "default.yml"
+with _CONFIG_PATH.open() as fh:
+    _CONFIG = yaml.safe_load(fh)
+
+db_path = os.path.expanduser(_CONFIG.get("player_database"))
+
+def check_for(path: str | None = None) -> bool:
+    """Determine whether a filesystem path exists.
+
+    Parameters
+    ----------
+    path:
+        A specific path to check.  When ``None`` (the default), the function
+        uses the ``player_database`` path loaded from the configuration file.
+
+    Returns
+    -------
+    bool
+        ``True`` if the path exists, otherwise ``False``.
+    """
+
+    target = os.path.abspath(os.path.expanduser(path or db_path))
+    return os.path.exists(target)


### PR DESCRIPTION
## Summary
- read player database path from YAML config instead of missing setup_env module
- document `check_for` utility and expose default `os` import

## Testing
- `python - <<'PY'
import sys
sys.path.append('/workspace/monopolpy_companion/monopolpy_companion')
from lib.common.utilities.db_man import check_for
print('missing:', check_for('this/path/does/not/exist'))
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0c86a21c8832dbac72146ea68adf2

## Summary by Sourcery

Load the player database path from the default YAML config and enhance the check_for utility with documentation, type hints, and simplified path resolution.

New Features:
- Load player database path from project YAML configuration instead of relying on setup_env

Enhancements:
- Add docstring, type annotations, and unified path handling to the check_for utility
- Remove deprecated setup_env import and import os directly

Documentation:
- Document the behavior and parameters of the check_for function