### PR TITLE
Persist GUI configuration changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ pyvenv.cfg
 /lib64
 /include
 /dist
+monopolpy_companion/conf/user.yml

--- a/monopolpy_companion/lib/common/settings.py
+++ b/monopolpy_companion/lib/common/settings.py
@@ -1,5 +1,7 @@
 import logging
 from pathlib import Path
+from typing import Optional
+
 import yaml
 
 
@@ -9,23 +11,48 @@ logger = logging.getLogger('MonopolpyCompanion.' + __name__)
 class Config:
     """Configuration handler for the application."""
 
-    def __init__(self, file=None):
+    def __init__(self, file: Optional[Path] = None):
         logger.info(f'Logger started for {logger.name}')
+        root = Path(__file__).resolve().parents[2]
+        self._default_file = root / 'conf' / 'default.yml'
+        self._user_file = root / 'conf' / 'user.yml'
+        self._path: Optional[Path] = None
         self.data = self.load(file)
 
-    def load(self, file=None):
+    @property
+    def path(self) -> Optional[Path]:
+        """Return the path that configuration writes will target."""
+
+        return self._path
+
+    def load(self, file: Optional[Path] = None):
         """Load configuration data from *file*.
 
-        Falls back to the default configuration file when *file* is ``None``.
+        Falls back to the saved user configuration when ``file`` is ``None``.
+        If no user configuration exists, the bundled defaults are used for
+        reading while future writes target the user configuration path.
+
         Missing keys are handled gracefully with defaults and warnings logged
         instead of printing to stdout.
         """
-        if file is None:
-            logger.debug('A custom config file was not provided!')
-            file = Path(__file__).resolve().parents[2] / 'conf' / 'default.yml'
 
-        with open(file) as res:
-            data = yaml.safe_load(res)
+        if file is not None:
+            load_path = Path(file)
+            target_path = load_path
+        else:
+            if self._user_file.exists():
+                load_path = self._user_file
+                target_path = self._user_file
+            else:
+                logger.debug('A custom config file was not provided!')
+                load_path = self._default_file
+                target_path = self._user_file
+
+        logger.debug('Loading configuration from %s', load_path)
+        with open(load_path) as res:
+            data = yaml.safe_load(res) or {}
+
+        self._path = target_path
 
         gui_settings = data.setdefault('gui_settings', {})
         if gui_settings.get('grab_anywhere') is None:
@@ -34,17 +61,26 @@ class Config:
 
         return data
 
-    def write(self, file=None):
+    def write(self, file: Optional[Path] = None):
         """Write configuration data to *file*.
 
-        If *file* is ``None``, the default configuration path is used.
+        If *file* is ``None``, the most appropriate user configuration path is
+        used.
         """
-        if file is None:
-            logger.warning('Output file not provided; using default file')
-            file = Path(__file__).resolve().parents[2] / 'conf' / 'default.yml'
 
-        with open(file, 'w') as outfile:
+        if file is not None:
+            target = Path(file)
+        else:
+            if self._path is None:
+                logger.warning('Output file not provided; using default user file')
+                self._path = self._user_file
+            target = self._path
+
+        target.parent.mkdir(parents=True, exist_ok=True)
+        logger.debug('Writing configuration to %s', target)
+        with open(target, 'w') as outfile:
             yaml.safe_dump(self.data, outfile, default_flow_style=False)
+        self._path = target
 
 
 if __name__ == '__main__':

--- a/monopolpy_companion/lib/common/settings.py
+++ b/monopolpy_companion/lib/common/settings.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Tuple
 
 import yaml
 
@@ -19,6 +19,31 @@ class Config:
         self._path: Optional[Path] = None
         self.data = self.load(file)
 
+    def _resolve_load_paths(self, file: Optional[Path]) -> Tuple[Path, Path]:
+        """Return the source and target paths for a load request."""
+
+        if file is not None:
+            load_path = Path(file)
+            return load_path, load_path
+
+        if self._user_file.exists():
+            return self._user_file, self._user_file
+
+        logger.debug('A custom config file was not provided!')
+        return self._default_file, self._user_file
+
+    def _resolve_write_target(self, file: Optional[Path]) -> Path:
+        """Return the path to which configuration writes should be sent."""
+
+        if file is not None:
+            return Path(file)
+
+        if self._path is None:
+            logger.warning('Output file not provided; using default user file')
+            self._path = self._user_file
+
+        return self._path
+
     @property
     def path(self) -> Optional[Path]:
         """Return the path that configuration writes will target."""
@@ -36,17 +61,7 @@ class Config:
         instead of printing to stdout.
         """
 
-        if file is not None:
-            load_path = Path(file)
-            target_path = load_path
-        else:
-            if self._user_file.exists():
-                load_path = self._user_file
-                target_path = self._user_file
-            else:
-                logger.debug('A custom config file was not provided!')
-                load_path = self._default_file
-                target_path = self._user_file
+        load_path, target_path = self._resolve_load_paths(file)
 
         logger.debug('Loading configuration from %s', load_path)
         with open(load_path) as res:
@@ -68,13 +83,7 @@ class Config:
         used.
         """
 
-        if file is not None:
-            target = Path(file)
-        else:
-            if self._path is None:
-                logger.warning('Output file not provided; using default user file')
-                self._path = self._user_file
-            target = self._path
+        target = self._resolve_write_target(file)
 
         target.parent.mkdir(parents=True, exist_ok=True)
         logger.debug('Writing configuration to %s', target)

--- a/monopolpy_companion/lib/gui/models/windows/__init__.py
+++ b/monopolpy_companion/lib/gui/models/windows/__init__.py
@@ -6,7 +6,8 @@ from monopolpy_companion.lib.gui.models.images.icons.main_default import icon as
 from monopolpy_companion.lib.gui.models.images.buttons.app_win import start_new_button_img, load_saved_button_img
 
 
-CONF = Config().data
+CONFIG = Config()
+CONF = CONFIG.data
 
 
 app_win = MainWindow(
@@ -44,7 +45,7 @@ def window():
             from monopolpy_companion.lib.gui.models.windows.options import OptionsWindow
 
             opts_win_active = True
-            OptionsWindow(CONF)
+            OptionsWindow(CONFIG)
             opts_win_active = False
 
         if event == 'start_new_main_button':

--- a/monopolpy_companion/lib/gui/models/windows/application/window.py
+++ b/monopolpy_companion/lib/gui/models/windows/application/window.py
@@ -60,7 +60,7 @@ colors, fonts, etc.
     _layout_builder: MonopolyMainLayout = field(init=False, repr=False)
     _pil_img: Optional[Image.Image] = field(default=None, init=False, repr=False)
     _photo: Optional[ImageTk.PhotoImage] = field(default=None, init=False, repr=False)
-    _content_container: Optional[int] = field(default=None, init=False, repr=False)
+    _content_container: Optional[tk.Widget] = field(default=None, init=False, repr=False)
     window: Optional[sg.Window] = field(default=None, init=False)
     canvas: Optional[tk.Canvas] = field(default=None, init=False)
 
@@ -78,7 +78,10 @@ colors, fonts, etc.
     def construct(self) -> sg.Window:
         """Build and return the sg.Window with background and content layout."""
         if self.theme:
-            sg.theme(self.theme)
+            if hasattr(sg, "theme"):
+                sg.theme(self.theme)
+            else:
+                sg.set_options(theme=self.theme)
 
         if self.bg_image_path:
             self._pil_img = Image.open(self.bg_image_path).convert('RGBA')
@@ -118,13 +121,25 @@ colors, fonts, etc.
 
         cw, ch = self.canvas.winfo_width(), self.canvas.winfo_height()
         col_widget = self._content_column.Widget
-        self._content_container = self.canvas.create_window(
-            cw // 2, ch // 2, window=col_widget, anchor=tk.CENTER
-        )
+        frame_widget = col_widget.master
+        # Detach from pack and overlay the column's frame above the canvas
+        try:
+            frame_widget.pack_forget()
+        except Exception:
+            pass
+        fx = self.canvas.winfo_x() + cw // 2
+        fy = self.canvas.winfo_y() + ch // 2
+        # Overlay the column's Frame on top of the canvas and make it visible
+        frame_widget.place(in_=self.window.TKroot, x=fx, y=fy, anchor=tk.CENTER)
+        frame_widget.tkraise()
+        self._content_column.update(visible=True)
+        self._content_container = frame_widget
 
         def _on_resize(event):
             try:
-                self.canvas.coords(self._content_container, event.width // 2, event.height // 2)
+                fx = self.canvas.winfo_x() + event.width // 2
+                fy = self.canvas.winfo_y() + event.height // 2
+                self._content_container.place_configure(x=fx, y=fy)
             except Exception:
                 pass
             if self.enable_bg_autoscale:

--- a/monopolpy_companion/lib/gui/models/windows/options.py
+++ b/monopolpy_companion/lib/gui/models/windows/options.py
@@ -30,7 +30,12 @@ class OptionsWindow:
         log.debug(f'New active state: {opts_win_active}')
         self.active = opts_win_active
 
-        conf = config
+        self._config_obj = None
+        if hasattr(config, 'data') and hasattr(config, 'write'):
+            self._config_obj = config
+            conf = config.data
+        else:
+            conf = config
         self.conf = conf
 
         self.opts_playman_frame = [
@@ -54,9 +59,14 @@ class OptionsWindow:
             [gui.Button('OK', key='opts_ok'), gui.Cancel(key='opts_cancel'), gui.Button('Apply', key='opts_apply')]
             ]
 
-        self.opts_win = gui.Window('Monopolpy Companion Options', self.layout, grab_anywhere=self.conf['gui_settings'][
-            'grab_anywhere'],
-                                   background_image='thing.png', size=(400, 200))
+        import inspect
+        window_kwargs = {
+            'grab_anywhere': self.conf['gui_settings']['grab_anywhere'],
+            'size': (400, 200)
+        }
+        if 'background_image' in inspect.signature(gui.Window.__init__).parameters:
+            window_kwargs['background_image'] = 'thing.png'
+        self.opts_win = gui.Window('Monopolpy Companion Options', self.layout, **window_kwargs)
         from monopolpy_companion.lib.common.run import pm_active
 
         log.debug(f'Imported active state of the Player Manager window which is: {pm_active}')
@@ -67,9 +77,7 @@ class OptionsWindow:
 
             if event == 'opts_ok' or event == 'opts_apply':
                 log.debug('User is attempting to save config to file')
-                from monopolpy_companion.lib.helpers.popup_man import nyi
-
-                nyi('Save Config')
+                self.save_config(values)
 
             if event == 'opts_ok':
                 log.debug('User pressed OK in the options window')
@@ -95,3 +103,34 @@ class OptionsWindow:
                 return self.conf['gui_settings']['grab_anywhere']
             except KeyError:
                 return False
+
+    def save_config(self, values):
+        """Persist the configuration using the active Config instance."""
+
+        if self.conf is None:
+            self.log.error('Configuration not loaded; cannot save')
+            return
+
+        gui_settings = self.conf.setdefault('gui_settings', {})
+        new_grab_anywhere = bool(values.get('grab_anywhere_box'))
+        old_grab_anywhere = gui_settings.get('grab_anywhere')
+        gui_settings['grab_anywhere'] = new_grab_anywhere
+        if old_grab_anywhere != new_grab_anywhere:
+            self.log.debug(
+                "Updated 'grab_anywhere' from %s to %s",
+                old_grab_anywhere,
+                new_grab_anywhere,
+            )
+
+        if self._config_obj is not None:
+            try:
+                self._config_obj.write()
+                path = getattr(self._config_obj, 'path', None)
+                if path:
+                    self.log.info('Configuration saved to %s', path)
+                else:
+                    self.log.info('Configuration saved')
+            except Exception:
+                self.log.exception('Failed to save configuration to disk')
+        else:
+            self.log.warning('No Config instance supplied; changes not persisted to disk')

--- a/monopolpy_companion/lib/gui/models/windows/options.py
+++ b/monopolpy_companion/lib/gui/models/windows/options.py
@@ -1,3 +1,6 @@
+from yaml import YAMLError
+
+
 class OptionsWindow:
     """ Define information for the 'Options' window """
 
@@ -59,13 +62,17 @@ class OptionsWindow:
             [gui.Button('OK', key='opts_ok'), gui.Cancel(key='opts_cancel'), gui.Button('Apply', key='opts_apply')]
             ]
 
-        import inspect
         window_kwargs = {
             'grab_anywhere': self.conf['gui_settings']['grab_anywhere'],
             'size': (400, 200)
         }
-        if 'background_image' in inspect.signature(gui.Window.__init__).parameters:
-            window_kwargs['background_image'] = 'thing.png'
+        version = getattr(gui, '__version__', None)
+        try:
+            major_version = int(str(version).split('.', 1)[0]) if version else None
+        except ValueError:
+            major_version = None
+        if major_version is not None and major_version < 5:
+            window_kwargs['background_image'] = self.conf['gui_settings'].get('background_image', 'thing.png')
         self.opts_win = gui.Window('Monopolpy Companion Options', self.layout, **window_kwargs)
         from monopolpy_companion.lib.common.run import pm_active
 
@@ -75,7 +82,7 @@ class OptionsWindow:
 
             event, values = self.opts_win.read(timeout=100)
 
-            if event == 'opts_ok' or event == 'opts_apply':
+            if event in ('opts_ok', 'opts_apply'):
                 log.debug('User is attempting to save config to file')
                 self.save_config(values)
 
@@ -125,12 +132,12 @@ class OptionsWindow:
         if self._config_obj is not None:
             try:
                 self._config_obj.write()
-                path = getattr(self._config_obj, 'path', None)
-                if path:
+            except (OSError, YAMLError):
+                self.log.exception('Failed to save configuration to disk')
+            else:
+                if path := getattr(self._config_obj, 'path', None):
                     self.log.info('Configuration saved to %s', path)
                 else:
                     self.log.info('Configuration saved')
-            except Exception:
-                self.log.exception('Failed to save configuration to disk')
         else:
             self.log.warning('No Config instance supplied; changes not persisted to disk')


### PR DESCRIPTION
## Summary
- Overlay content frame above Tk canvas via root placement to avoid Tkinter window errors
- Handle PySimpleGUI 5 theme API change with fallback to `set_options`
- Raise content layout above board and make it visible so UI elements render
- Pass `background_image` to Options window only when supported by the running PySimpleGUI version
- Persist GUI configuration by writing Options window changes to a user config file that is loaded on startup

## Testing
- `pytest`
- `python app.py --gui` *(not run: GUI requires a display in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c76bc586c0832d9d173686b9c39744

## Summary by Sourcery

Refactor configuration handling to persist GUI settings to a user file and update window classes for improved rendering and compatibility

New Features:
- Persist GUI configuration changes by writing Options window adjustments to a user-specific config file that is loaded on startup

Enhancements:
- Refactor Config class to manage bundled defaults and user config paths, track target path, and write updates to disk
- Update OptionsWindow to accept a Config instance, detect API changes for background_image, and save updated settings via a new save_config method
- Adapt MainWindow to overlay the content frame above the Tk canvas using place and tkraise and provide a fallback for the PySimpleGUI theme API change